### PR TITLE
Correctly label the license in the mod properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ mod.group=com.redsmods.sound_physics_perfected
 mod.description=Ray Traced Audio Implementation!!
 mod.source=https://github.com/FalseMSP/SoundPhysicsPerfected
 mod.issues=https://github.com/FalseMSP/SoundPhysicsPerfected/issues
-mod.license=CC0-1.0
+mod.license=MIT
 mod.modrinth=https://modrinth.com/mod/sound-physics-perfected
 mod.discord=https://discord.gg/dMAsTxbVar
 


### PR DESCRIPTION
This was a bit of an oversight when I initially transferred the mod properties. This change corrects that.