### PR TITLE
Use isClientSide's getter instead of direct

### DIFF
--- a/src/main/java/com/redsmods/sound_physics_perfected/RaycastingHelper.java
+++ b/src/main/java/com/redsmods/sound_physics_perfected/RaycastingHelper.java
@@ -909,7 +909,7 @@ public class RaycastingHelper {
     }
 
     public static void displayEntityRayHitCounts(Level world, Player player) {
-        if (world.isClientSide && !entityRayHitCounts.isEmpty()) {
+        if (world.isClientSide() && !entityRayHitCounts.isEmpty()) {
             for (Map.Entry<SoundData, Integer> entry : entityRayHitCounts.entrySet()) {
                 SoundData entity = entry.getKey();
                 int rayCount = entry.getValue();

--- a/src/main/java/com/redsmods/sound_physics_perfected/mixin/client/PlayerEntityMixin.java
+++ b/src/main/java/com/redsmods/sound_physics_perfected/mixin/client/PlayerEntityMixin.java
@@ -20,7 +20,7 @@ public class PlayerEntityMixin {
         Level world = player.level();
 
         // Only run on client side to avoid server lag
-        if (!world.isClientSide) {
+        if (!world.isClientSide()) {
             return;
         }
 


### PR DESCRIPTION
This was something I found was changed in 1.21.9's snapshots. This also can apply to older versions that are already supported as this a bit of a better practice anyways.