### PR TITLE
Add 1.21.9 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,6 @@ loom.runs {
 
         configureEach {
             vmArg("-javaagent:$mixinJarFile") // Mixin Hotswap doesn't work on NeoForge, but doesn't hurt to keep
-            vmArg("-XX:+AllowEnhancedClassRedefinition")
 
             property("mixin.hotSwap", "true")
             property("mixin.debug.export", "true") // Puts mixin outputs in /run/.mixin.out

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,11 +19,11 @@ publish.modrinth=
 publish.curseforge=
 
 # Dependencies
-deps.fabric_loader_version=0.16.14
+deps.fabric_loader_version=0.17.2
 deps.devauth_version=1.2.1
 deps.mixinconstraints_version=1.1.0
 deps.mixinsquared_version=0.2.0
-deps.yacl_version=3.7.1
+deps.yacl_version=3.8.0
 deps.voicechat_api_version=2.6.0
 
 # Build Plugins

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
 }
 
 plugins {
-	id("dev.kikugie.stonecutter") version "0.7.8"
+	id("dev.kikugie.stonecutter") version "0.7.10"
 }
 
 stonecutter {
@@ -30,7 +30,7 @@ stonecutter {
 		mc("1.21.1", listOf("fabric", "neoforge"))
 		mc("1.21.3", listOf("fabric", "neoforge"))
 		mc("1.21.6", listOf("fabric", "neoforge"))
-//		mc("1.21.9", listOf("fabric", "neoforge"))
+		mc("1.21.9", listOf("fabric"))
 
 		vcsVersion = "1.21.1-fabric"
 	}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
 		]
 	},
 	"depends": {
-		"fabricloader": ">=${fabric_loader_version}",
+		"fabricloader": "*",
 		"minecraft": "${mcdep}",
 		"java": ">=17",
 		"fabric-api": "*",

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.publishing)
 }
 
-stonecutter active "1.21.6-fabric" /* [SC] DO NOT EDIT */
+stonecutter active "1.21.9-fabric" /* [SC] DO NOT EDIT */
 
 stonecutter tasks {
     val ordering = Comparator

--- a/versions/1.21.6-fabric/gradle.properties
+++ b/versions/1.21.6-fabric/gradle.properties
@@ -5,4 +5,4 @@ deps.fabric_api_version=0.126.0
 deps.modmenu_version=15.0.0-beta.1
 
 mod.mc_version=1.21.6
-mod.mc_dep=>=1.21.6
+mod.mc_dep=>=1.21.6 <=1.21.8

--- a/versions/1.21.6-neoforge/gradle.properties
+++ b/versions/1.21.6-neoforge/gradle.properties
@@ -4,4 +4,4 @@ deps.parchment_version=2025.06.29
 deps.neoforge_version=21.6.0-beta
 
 mod.mc_version=1.21.6
-mod.mc_dep=>=1.21.6
+mod.mc_dep=>=1.21.6 <=1.21.8

--- a/versions/1.21.9-fabric/gradle.properties
+++ b/versions/1.21.9-fabric/gradle.properties
@@ -1,8 +1,8 @@
 loom.platform=fabric
 
-deps.parchment_version=2025.06.29
-deps.fabric_api_version=0.126.0
-deps.modmenu_version=15.0.0-beta.1
+deps.parchment_version=
+deps.fabric_api_version=0.134.0
+deps.modmenu_version=16.0.0-rc.1
 
-mod.mc_version=1.21.6
+mod.mc_version=1.21.9
 mod.mc_dep=>=1.21.9

--- a/versions/1.21.9-neoforge/gradle.properties
+++ b/versions/1.21.9-neoforge/gradle.properties
@@ -1,7 +1,7 @@
 loom.platform=neoforge
 
-deps.parchment_version=2025.09.14
-deps.neoforge_version=21.6.0-beta
+deps.parchment_version=
+deps.neoforge_version=21.9.0-beta
 
 mod.mc_version=1.21.9
 mod.mc_dep=>=1.21.9


### PR DESCRIPTION
Closes #93 

Technically, NeoForge *would* be supported but I can't even get a prod bare Neoforge prod environment to work, so I am not going to include it until there's a working build.

Parchment mappings are not officially released, but they are not necessary for the purposes of this port as no core codebase needed to be changed.

1.21.10 is close to being out, no changes should be necessary by that point, but I'll check in once it's officially released.