### PR TITLE
Add Parchment and proper YACL version to 1.21.9

### DIFF
--- a/versions/1.21.9-fabric/gradle.properties
+++ b/versions/1.21.9-fabric/gradle.properties
@@ -1,8 +1,9 @@
 loom.platform=fabric
 
-deps.parchment_version=
+deps.parchment_version=2025.10.05
 deps.fabric_api_version=0.134.0
 deps.modmenu_version=16.0.0-rc.1
+deps.yacl_version=3.8.0
 
 mod.mc_version=1.21.9
 mod.mc_dep=>=1.21.9

--- a/versions/1.21.9-neoforge/gradle.properties
+++ b/versions/1.21.9-neoforge/gradle.properties
@@ -1,7 +1,8 @@
 loom.platform=neoforge
 
-deps.parchment_version=
+deps.parchment_version=2025.10.05
 deps.neoforge_version=21.9.0-beta
+deps.yacl_version=3.8.0
 
 mod.mc_version=1.21.9
 mod.mc_dep=>=1.21.9


### PR DESCRIPTION
Parchment was finally released recently. This also brings back YACL 3.8.0, but specifically for 1.21.9. This is a requirement, as 3.7.1 will crash on 1.21.9 in the development environment.